### PR TITLE
Fix exception on Posting Job with Notification Set

### DIFF
--- a/src/Speechmatics.Client/SpeechmaticsApiClient.cs
+++ b/src/Speechmatics.Client/SpeechmaticsApiClient.cs
@@ -126,14 +126,14 @@ namespace Speechmatics.Client
                 content.Add(new StringContent(model), "model");
 
                 // add optional parameters
-                if (notification != null)
-                    content.Add(new StringContent(notification.ToEnumString()), "notification");
+                if (notification.HasValue)
+                    content.Add(new StringContent(notification.Value.ToEnumString()), "notification");
                 if (callback != null)
                     content.Add(new StringContent(callback.ToString()), "callback");
                 if (meta != null)
                     content.Add(new StringContent(meta), "meta");
-                if (diarisation != null)
-                    content.Add(new StringContent((bool)diarisation ? "true" : "false"), "diarisation");
+                if (diarisation.HasValue)
+                    content.Add(new StringContent(diarisation.Value ? "true" : "false"), "diarisation");
                 reqs.Content = content;
 
                 // send request


### PR DESCRIPTION
Rather than using the value of the nullable enum type, the nullable itself
is trying to be parsed into the enum type.  Fix by using the Value
property.  Fixes #1